### PR TITLE
Add unix socket support for --opcache.fcgi-uri parameter with backwards compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,24 @@ $ opcache_exporter [<flags>]
 
 Flags:
   -h, --help                    Show context-sensitive help (also try --help-long and --help-man).
-      --web.listen-address=":9101"  
+      --web.listen-address=":9101"
                                 Address to listen on for web interface and telemetry.
-      --web.telemetry-path="/metrics"  
+      --web.telemetry-path="/metrics"
                                 Path under which to expose metrics.
-      --opcache.fcgi-uri="127.0.0.1:9000"  
+      --opcache.fcgi-uri="tcp://127.0.0.1:9000"
                                 Connection string to FastCGI server.
       --opcache.script-path=""  Path to PHP script which echoes json-encoded OPcache status
       --opcache.script-dir=""   Path to directory where temporary PHP file will be created
 ```
 
+Set --opcache.fcgi-uri to a uri such as tcp://127.0.0.1:9000 if php-fpm is listening on a tcp socket or unix:///path/to/php.sock for a unix socket.
+
 ## License
 <pre>
 Copyright © 2020 Crowdin
 
-The Crowdin OPcache exporter is licensed under the MIT License. 
-See the LICENSE file distributed with this work for additional 
+The Crowdin OPcache exporter is licensed under the MIT License.
+See the LICENSE file distributed with this work for additional
 information regarding copyright ownership.
 
 Except as contained in the LICENSE file, the name(s) of the above copyright

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -19,7 +19,7 @@ func main() {
 	var (
 		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9101").String()
 		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-		fcgiURI       = kingpin.Flag("opcache.fcgi-uri", "Connection string to FastCGI server.").Default("127.0.0.1:9000").String()
+		fcgiURI       = kingpin.Flag("opcache.fcgi-uri", "Connection string to FastCGI server.").Default("tcp://127.0.0.1:9000").String()
 		scriptPath    = kingpin.Flag("opcache.script-path", "Path to PHP script which echoes json-encoded OPcache status").Default("").String()
 		scriptDir     = kingpin.Flag("opcache.script-dir", "Path to directory where temporary PHP file will be created").Default("").String()
 	)


### PR DESCRIPTION
This PR adds support for a user-configurable scheme for the fcgi connection. This makes it possible to use this exporter with php-fpm servers that only expose a unix socket.

I've added backwards compatibility for the old default `--opcache.fcgi-uri="127.0.0.1:9000"` (or any other `IP:PORT` combination without a scheme) to default to `tcp`.